### PR TITLE
Add alias target for doctest_with_main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 
 if(${DOCTEST_WITH_MAIN_IN_STATIC_LIB})
     add_library(${PROJECT_NAME}_with_main STATIC EXCLUDE_FROM_ALL ${doctest_parts_folder}/doctest.cpp)
+    add_library(${PROJECT_NAME}::${PROJECT_NAME}_with_main ALIAS ${PROJECT_NAME}_with_main)
     target_compile_definitions(${PROJECT_NAME}_with_main PRIVATE
         DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN)
     set_target_properties(${PROJECT_NAME}_with_main PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Description

I've added the alias `doctest::doctest_with_main` for the library target `doctest_with_main`.

## Motivation

There already is the alias `doctest::doctest` for the library target `doctest`, so this will increase consistency.
Indeed, I've recently tried the alias `doctest::doctest_with_main` for my personal projects and was surprised it didn't exist.